### PR TITLE
Fix package.json `types` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bin/*",
     "types/*"
   ],
-  "types": "./types/*.d.ts",
+  "types": "./types/action-yml.d.ts",
   "scripts": {
     "build": "npm run build:cli",
     "build:cli": "ncc build src/cli.ts -o bin",


### PR DESCRIPTION
I recently installed your package to get proper types for the `action.yml` file of a GitHub Action (thanks for this btw, it's really helpful). Altho, after importing it using a basic syntax, my LSP was complaining about the types not being found.

```ts
import { type ActionDefinition } from '@xt0rted/actions-toolkit'
```

It turns out, the issue was related to the `package.json` file and more specifically the `types` field. It is currently using a glob pattern to match the types file (`"types": "./types/*.d.ts"`). I have never encountered this syntax before, and even after looking it up, this doesn't seem to be a valid syntax for the `types` field. According to [the documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html), only the `typesVersions` field supports glob patterns.

After [patching the field in my project](https://github.com/HiDeoo/changelogithub-action/blob/8eddd77b213b2fc91d796dbd7deaeb12e84b4831/patches/%40xt0rted__actions-toolkit%400.0.1.patch) to point to `./types/action-yml.d.ts`, TypeScript was able to find the types and everything worked as expected.
